### PR TITLE
virt: Add PCI host controller

### DIFF
--- a/hw/arc/Kconfig
+++ b/hw/arc/Kconfig
@@ -2,6 +2,8 @@ config ARC_VIRT
     bool
     select SERIAL
     select VIRTIO_MMIO
+    select PCI_EXPRESS_GENERIC_BRIDGE
+    select PCI_DEVICES
 
 config ARC
     bool


### PR DESCRIPTION
This adds PCI bridge support to ARC's `virt` platform, which in its turn allows to both connect complex Virtio devices like VirtGPU, VirtRNG as well as pass-through host PCI devices including USB.

Note this requires corresponding support in the Linux kernel like this:
```diff
diff --git a/arch/arc/Kconfig b/arch/arc/Kconfig
index ba00c4e1e1c2..09efd393a0b2 100644
--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -48,6 +48,7 @@ config ARC
        select PCI_SYSCALL if PCI
        select PERF_USE_VMALLOC if ARC_CACHE_VIPT_ALIASING
        select HAVE_ARCH_JUMP_LABEL if ISA_ARCV2 && !CPU_ENDIAN_BE32
+       select HAVE_PCI

 config ARCH_HAS_CACHE_LINE_SIZE
        def_bool y
diff --git a/arch/arc/boot/dts/haps_hs.dts b/arch/arc/boot/dts/haps_hs.dts
index 60d578e2781f..c57c7381c468 100644
--- a/arch/arc/boot/dts/haps_hs.dts
+++ b/arch/arc/boot/dts/haps_hs.dts
@@ -95,5 +95,45 @@ virtio4: virtio@f0108000 {
                        reg = <0xf0108000 0x2000>;
                        interrupts = <35>;
                };
+
+               pci {
+                       compatible = "pci-host-ecam-generic";
+                       device_type = "pci";
+                       #address-cells = <3>;
+                       #size-cells = <2>;
+                       #interrupt-cells = <0x1>;
+
+                       bus-range = <0x0 0x0>;
+                       reg = <0xe0000000 0x1000000>;
+
+                       // BUS_ADDRESS(3)  CPU_PHYSICAL(1)  SIZE(2)
+                       ranges = <0x01000000 0x0 0x00000000  0xc0000000  0x0 0x00010000>, /* PIO */
+                                <0x02000000 0x0 0xd0000000  0xd0000000  0x0 0x10000000>; /* MMIO */
+
+                       // PCI_DEVICE(3)  INT#(1)  CONTROLLER(PHANDLE)  CONTROLLER_IRQ(1)
+                       interrupt-map = <
+                               0x0000 0x0 0x0  0x1  &core_intc  40 /* 1st slot */
+                               0x0000 0x0 0x0  0x2  &core_intc  41
+                               0x0000 0x0 0x0  0x3  &core_intc  42
+                               0x0000 0x0 0x0  0x4  &core_intc  43
+
+                               0x0800 0x0 0x0  0x1  &core_intc  41 /* 2nd slot */
+                               0x0800 0x0 0x0  0x2  &core_intc  42
+                               0x0800 0x0 0x0  0x3  &core_intc  43
+                               0x0800 0x0 0x0  0x4  &core_intc  40
+
+                               0x1000 0x0 0x0  0x1  &core_intc  42 /* 3rd slot */
+                               0x1000 0x0 0x0  0x2  &core_intc  43
+                               0x1000 0x0 0x0  0x3  &core_intc  40
+                               0x1000 0x0 0x0  0x4  &core_intc  41
+
+                               0x1800 0x0 0x0  0x1  &core_intc  43 /* 4th slot */
+                               0x1800 0x0 0x0  0x2  &core_intc  40
+                               0x1800 0x0 0x0  0x3  &core_intc  41
+                               0x1800 0x0 0x0  0x4  &core_intc  42
+                               >;
+
+                       interrupt-map-mask = <0x1800 0x0 0x0  0x7>;
+               };
        };
 };
diff --git a/arch/arc/configs/haps_hs_defconfig b/arch/arc/configs/haps_hs_defconfig
index 86cc5aa4537c..25b0bcd34782 100644
--- a/arch/arc/configs/haps_hs_defconfig
+++ b/arch/arc/configs/haps_hs_defconfig
@@ -31,6 +31,8 @@ CONFIG_NET_KEY=y
 CONFIG_INET=y
 # CONFIG_IPV6 is not set
 # CONFIG_WIRELESS is not set
+CONFIG_PCI=y
+CONFIG_PCI_HOST_GENERIC=y
 CONFIG_DEVTMPFS=y
 CONFIG_DEVTMPFS_MOUNT=y
 # CONFIG_STANDALONE is not set
@@ -51,10 +53,16 @@ CONFIG_SERIAL_8250_NR_UARTS=1
 CONFIG_SERIAL_8250_RUNTIME_UARTS=1
 CONFIG_SERIAL_8250_DW=y
 CONFIG_SERIAL_OF_PLATFORM=y
-# CONFIG_HW_RANDOM is not set
+CONFIG_HW_RANDOM=y
+CONFIG_HW_RANDOM_VIRTIO=y
 # CONFIG_HWMON is not set
-# CONFIG_HID is not set
-# CONFIG_USB_SUPPORT is not set
+CONFIG_DRM=y
+CONFIG_DRM_VIRTIO_GPU=y
+CONFIG_USB=y
+CONFIG_USB_XHCI_HCD=y
+CONFIG_USB_EHCI_HCD=y
+CONFIG_USB_OHCI_HCD=y
+CONFIG_VIRTIO_PCI=y
 CONFIG_VIRTIO_MMIO=y
 # CONFIG_IOMMU_SUPPORT is not set
 CONFIG_EXT2_FS=y
```

```
./build/qemu-system-arc -M virt -monitor none -serial mon:stdio -kernel vmlinux -cpu archs \
    -append "root=/dev/vda ro" -drive file=rootfs.ext2,format=raw,id=hd0 -device virtio-blk-device,drive=hd0 \
    -netdev user,id=eth0 -device virtio-net-pci,netdev=eth0 -device virtio-rng-pci -device usb-ehci,id=ehci \
    --global cpu.freq_hz=50000000 -device virtio-gpu-pci,id=video0 -display gtk,gl=on \
    -device usb-host,vendorid=0x8564,productid=0x1000
```

And that's what we get:
1. Host's random number generator in the guest for faster entropy generation.
2. Real USB flash-drive attached to host passed-through to the guest
3. 3D rendering off-loaded to the host and so working even faster than on the original HSDK, see 100+ FPS

![render1612390013418-min](https://user-images.githubusercontent.com/1618098/106816469-79337b80-6686-11eb-90fb-11dda5efd466.gif)

![Screenshot from 2021-02-03 14-50-09 (3)](https://user-images.githubusercontent.com/1618098/106816538-95371d00-6686-11eb-9029-aa03fa6dba48.png)

![Screenshot from 2021-02-03 14-50-56 (2)](https://user-images.githubusercontent.com/1618098/106816549-99fbd100-6686-11eb-8333-a4078b4f423d.png)

![Screenshot from 2021-02-03 14-51-15 (2)](https://user-images.githubusercontent.com/1618098/106816560-9d8f5800-6686-11eb-9f7a-61e9738865e7.png)

