### PR TITLE
[excp] Initialise "env->host_pc" first thing in helper_{lr,sr}

### DIFF
--- a/target/arc/op_helper.c
+++ b/target/arc/op_helper.c
@@ -115,6 +115,9 @@ static void report_aux_reg_error(uint32_t aux)
 
 void helper_sr(CPUARCState *env, uint32_t val, uint32_t aux)
 {
+    /* saving return address in case an exception must be raised later */
+    env->host_pc = GETPC();
+
     struct arc_aux_reg_detail *aux_reg_detail =
         arc_aux_reg_struct_for_address(aux, ARC_OPCODE_ARCv2HS);
 
@@ -123,9 +126,6 @@ void helper_sr(CPUARCState *env, uint32_t val, uint32_t aux)
         report_aux_reg_error(aux);
         arc_raise_exception(env, EXCP_INST_ERROR);
     }
-
-    /* saving return address in case an exception must be raised later */
-    env->host_pc = GETPC();
 
     switch (aux_reg_detail->id) {
     case AUX_ID_lp_start:
@@ -209,6 +209,9 @@ target_ulong helper_lr(CPUARCState *env, uint32_t aux)
     ARCCPU *cpu = env_archcpu(env);
     target_ulong result = 0;
 
+    /* saving return address in case an exception must be raised later */
+    env->host_pc = GETPC();
+
     struct arc_aux_reg_detail *aux_reg_detail =
         arc_aux_reg_struct_for_address(aux, ARC_OPCODE_ARCv2HS);
 
@@ -216,9 +219,6 @@ target_ulong helper_lr(CPUARCState *env, uint32_t aux)
         report_aux_reg_error(aux);
         arc_raise_exception(env, EXCP_INST_ERROR);
     }
-
-    /* saving return address in case an exception must be raised later */
-    env->host_pc = GETPC();
 
     switch (aux_reg_detail->id) {
     case AUX_ID_aux_volatile:


### PR DESCRIPTION
"helper_{lr,sr}()" use "arc_raise_exception()" to raise an exception
if necessary. The "arc_raise_exception()" relies on the fact that
"env->host_pc" is initialised correctly.

Currently, there are control flow paths in "helper_{lr,sr}()" that
may invoke "arc_raise_exception()" without having the "env->host_pc"
initialised properly. This change, initialises "env->host_pc" first
thing in both "helper_{lr,sr}()".