### PR TITLE
usermode: Fix strace build for old platforms

### DIFF
--- a/linux-user/strace.c
+++ b/linux-user/strace.c
@@ -12,6 +12,7 @@
 #include <linux/if_packet.h>
 #include <linux/in6.h>
 #include <linux/netlink.h>
+#include <linux/falloc.h>
 #include <sched.h>
 #include "qemu.h"
 


### PR DESCRIPTION
Got following error on CentOS 7:
../linux-user/strace.c:1209:18: error: 'FALLOC_FL_KEEP_SIZE' undeclared here (not in a function)
 1209 |     FLAG_GENERIC(FALLOC_FL_KEEP_SIZE),
      |                  ^~~~~~~~~~~~~~~~~~~
../linux-user/strace.c:48:30: note: in definition of macro 'FLAG_GENERIC'
   48 | #define FLAG_GENERIC(name) { name, #name }
      |                              ^~~~
../linux-user/strace.c:1210:18: error: 'FALLOC_FL_PUNCH_HOLE' undeclared here (not in a function)
 1210 |     FLAG_GENERIC(FALLOC_FL_PUNCH_HOLE),
      |                  ^~~~~~~~~~~~~~~~~~~~
../linux-user/strace.c:48:30: note: in definition of macro 'FLAG_GENERIC'
   48 | #define FLAG_GENERIC(name) { name, #name }
      |                              ^~~~
ninja: build stopped: subcommand failed.
make[1]: *** [Makefile:152: run-ninja] Error 1
make[1]: Leaving directory '/SCRATCH/isaev/src/qemu/build'
make: *** [GNUmakefile:11: all] Error 2

Need to explicitly include <linux/falloc.h>.