### PR TITLE
add acceptance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - "^cuper.*"
+  pull_request:
+    branches: [master]
+
+env:
+  BUILD_DIR: ${{ github.workspace }}/build
+
+jobs:
+  build:
+    name: Build QEMU for ${{ matrix.host.name }}
+    runs-on: ${{ matrix.host.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - { name: linux-x86_64, runner: ubuntu-20.04 }
+          - { name: macos-x86_64, runner: macos-11 }
+
+    steps:
+      - name: Set up build environment (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          brew install ninja
+          echo "TAR=gtar" >> $GITHUB_ENV
+
+      - name: Set up build environment (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bison \
+            flex \
+            gettext \
+            help2man \
+            libncurses5-dev \
+            libtool-bin \
+            libtool-doc \
+            meson \
+            ninja-build \
+            tar \
+            texinfo
+
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow --tags --force
+
+      - name: Build QEMU
+        run: |
+          QEMU_TARGETS="arc-softmmu arc64-softmmu"
+          QEMU_FLAGS="--disable-werror"
+
+          # Target linux-user is only available on a Linux host
+          if [ "${{ matrix.host.name }}" == "linux-x86_64" ]; then
+            QEMU_TARGETS="${QEMU_TARGETS} arc-linux-user arc64-linux-user"
+          fi
+
+          ${{ github.workspace }}/configure \
+            ${QEMU_FLAGS} \
+            --target-list="${QEMU_TARGETS}" \
+            --prefix="${{ env.BUILD_DIR }}"
+
+          make -j $(nproc)
+
+      - name: Run acceptance tests
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          make check-avocado
+
+      - name: "Upload log"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.host.name }}.log
+          path: ${{ env.BUILD_DIR }}/tests/results/job-*/job.log
+        if: ${{ always() }}

--- a/tests/avocado/boot_linux_console.py
+++ b/tests/avocado/boot_linux_console.py
@@ -132,26 +132,6 @@ class BootLinuxConsole(LinuxKernelTest):
         console_pattern = 'Kernel command line: %s' % kernel_command_line
         self.wait_for_console_pattern(console_pattern)
 
-    def test_mips_malta(self):
-        """
-        :avocado: tags=arch:arc
-        """
-        deb_url = ('http://snapshot.debian.org/archive/debian/'
-                   '20130217T032700Z/pool/main/l/linux-2.6/'
-                   'linux-image-2.6.32-5-4kc-malta_2.6.32-48_mips.deb')
-        deb_hash = 'a8cfc28ad8f45f54811fc6cf74fc43ffcfe0ba04'
-        deb_path = self.fetch_asset(deb_url, asset_hash=deb_hash)
-        kernel_path = self.extract_from_deb(deb_path,
-                                            '/boot/vmlinux-archs')
-
-        self.vm.set_console()
-        kernel_command_line = self.KERNEL_COMMON_COMMAND_LINE + 'console=ttyS0'
-        self.vm.add_args('-kernel', kernel_path,
-                         '-append', kernel_command_line)
-        self.vm.launch()
-        console_pattern = 'Kernel command line: %s' % kernel_command_line
-        self.wait_for_console_pattern(console_pattern)
-
     def test_mips64el_malta(self):
         """
         This test requires the ar tool to extract "data.tar.gz" from
@@ -1044,17 +1024,6 @@ class BootLinuxConsole(LinuxKernelTest):
         console_pattern = 'Kernel command line: %s' % kernel_command_line
         self.wait_for_console_pattern(console_pattern)
 
-    def do_test_arc(self, kernel_name, console=0):
-        tar_url = ('https://github.com/cupertinomiranda/arc-qemu-resources/archive/master.tar.gz')
-        file_path = self.fetch_asset(tar_url)
-        archive.extract(file_path, self.workdir)
-
-        self.vm.set_console(console_index=console)
-        self.vm.add_args('-kernel',
-                         self.workdir + '/' + kernel_name)
-        self.vm.launch()
-        self.wait_for_console_pattern('QEMU advent calendar')
-
     def test_m68k_q800(self):
         """
         :avocado: tags=arch:m68k
@@ -1279,22 +1248,10 @@ class BootLinuxConsole(LinuxKernelTest):
         tar_hash = '49e88d9933742f0164b60839886c9739cb7a0d34'
         self.do_test_advcal_2018('02', tar_hash, 'santas-sleigh-ride.elf')
 
-    timeout = 240
-    def test_arc_virt(self):
-        """
-        :avocado: tags=arch:arc
-        :avocado: tags=machine:virt
-        """
-
-        tar_url = ('https://github.com/cupertinomiranda/'
-                   'arc-qemu-resources/archive/master.tar.gz')
-        file_path = self.fetch_asset(tar_url)
-        archive.extract(file_path, self.workdir)
-
-        kernel_path = self.workdir + '/arc-qemu-resources-master/vmlinux_archs'
+    def do_test_arc(self, kernel_url):
+        kernel_path = self.fetch_asset(kernel_url)
 
         self.vm.set_console()
-        kernel_command_line = (self.KERNEL_COMMON_COMMAND_LINE)
         self.vm.add_args('-kernel', kernel_path)
         self.vm.add_args('-device', 'virtio-net-device,netdev=net0')
         self.vm.add_args('-netdev', 'user,id=net0,hostfwd=tcp::5558-:21,hostfwd=tcp::5557-:23')
@@ -1302,3 +1259,25 @@ class BootLinuxConsole(LinuxKernelTest):
 
         console_pattern = 'Welcome to Buildroot'
         self.wait_for_console_pattern(console_pattern)
+
+    def test_arc_virt(self):
+        """
+        :avocado: tags=arch:arc
+        :avocado: tags=machine:virt
+        :avocado: tags=cpu:archs
+        """
+        kernel_url = ('https://github.com/temap/qemu-images/raw/'
+                      'master/'
+                      'vmlinux_archs')
+        self.do_test_arc(kernel_url)
+
+    def test_arc64_virt(self):
+        """
+        :avocado: tags=arch:arc64
+        :avocado: tags=machine:virt
+        :avocado: tags=cpu:hs6x
+        """
+        kernel_url = ('https://github.com/temap/qemu-images/raw/'
+                      'master/'
+                      'vmlinux_arc64')
+        self.do_test_arc(kernel_url)


### PR DESCRIPTION
This PR adds GitHub action that builds QEMU and runs acceptance tests. 

The primary motivation is to add smoke testing when new changes are pushed to master. It will help detect defects earlier instead of waiting for obscure reports from long-run integration testing from internal verification.

The further improvement is to trigger GH action when vmlinux images were updated in separate repositories.
The path to vmlinux images should be changed to foss owner before merging.