### PR TITLE
Revert icount-related chages in ARC Timers

### DIFF
--- a/target/arc/timer.c
+++ b/target/arc/timer.c
@@ -38,13 +38,8 @@
 
 static uint64_t get_ns(CPUARCState *env)
 {
-
 #ifndef CONFIG_USER_ONLY
-    if (icount_enabled()) {
-        return icount_get();
-    } else {
-      return qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL);
-    }
+    return qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL);
 #else
     return cpu_get_host_ticks();
 #endif
@@ -53,11 +48,7 @@ static uint64_t get_ns(CPUARCState *env)
 static uint32_t get_t_count(CPUARCState *env, uint32_t t)
 {
 #ifndef CONFIG_USER_ONLY
-    if (icount_enabled()) {
-        return icount_get() - env->timer[t].last_clk;
-    } else {
-        return NS_TO_CYCLE(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) - env->timer[t].last_clk);
-    }
+    return NS_TO_CYCLE(qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) - env->timer[t].last_clk);
 #else
     return cpu_get_host_ticks() - env->timer[t].last_clk;
 #endif


### PR DESCRIPTION
This is a partial revert of 08b0d73e2bce ("Added support for icount.").

`icount_get()` returns values in nanoseconds, not cycles. And so if we really want to use `icount_get()`, we need to convert it
to cycles as we used to do with `qemu_clock_get_ns()` via `NS_TO_CYCLE`.

But what's even more interesting, `icount_get()` is already used when icount is enabled through `qemu_clock_get_ns()` that way:
 * `qemu_clock_get_ns()` calls `cpus_get_virtual_clock()` in case of `QEMU_CLOCK_VIRTUAL`
 * `cpus_get_virtual_clock()` calls `cpus_accel->get_virtual_clock()`
 * `cpus_accel->get_virtual_clock()` = `icount_get()` if `icount_enabled()`

That fixes #63 (multiple Zephyr RTOS tests which used to fail due to a wrong timing calculations).