### PR TITLE
Overflowadd helper replacement

### DIFF
--- a/target/arc/helper.h
+++ b/target/arc/helper.h
@@ -32,7 +32,6 @@ DEF_HELPER_1(get_status32, tl, env)
 DEF_HELPER_3(set_status32_bit, void, env, tl, tl)
 
 DEF_HELPER_FLAGS_3(carry_add_flag, TCG_CALL_NO_RWG_SE, tl, tl, tl, tl)
-DEF_HELPER_FLAGS_3(overflow_add_flag, TCG_CALL_NO_RWG_SE, tl, tl, tl, tl)
 DEF_HELPER_FLAGS_3(overflow_sub_flag, TCG_CALL_NO_RWG_SE, tl, tl, tl, tl)
 DEF_HELPER_FLAGS_3(mpymu, TCG_CALL_NO_RWG_SE, tl, env, tl, tl)
 DEF_HELPER_FLAGS_3(mpym, TCG_CALL_NO_RWG_SE, tl, env, tl, tl)
@@ -44,7 +43,6 @@ DEF_HELPER_FLAGS_2(ffs32, TCG_CALL_NO_RWG_SE, tl, env, tl)
 
 DEF_HELPER_FLAGS_3(carry_add_flag32, TCG_CALL_NO_RWG_SE, tl, tl, tl, tl)
 DEF_HELPER_FLAGS_3(carry_sub_flag32, TCG_CALL_NO_RWG_SE, tl, tl, tl, tl)
-DEF_HELPER_FLAGS_3(overflow_add_flag32, TCG_CALL_NO_RWG_SE, tl, tl, tl, tl)
 DEF_HELPER_FLAGS_3(overflow_sub_flag32, TCG_CALL_NO_RWG_SE, tl, tl, tl, tl)
 
 DEF_HELPER_FLAGS_2(rotate_left32, TCG_CALL_NO_RWG_SE, i64, i64, i64)

--- a/target/arc/op_helper.c
+++ b/target/arc/op_helper.c
@@ -424,37 +424,6 @@ target_ulong helper_carry_add_flag(target_ulong dest, target_ulong b,
 }
 
 static inline target_ulong
-overflow_add_flag(target_ulong dest, target_ulong b, target_ulong c,
-                  uint8_t size)
-{
-    dest >>= (size - 1);
-    b    >>= (size - 1);
-    c    >>= (size - 1);
-
-    /*
-     * Truncate the result.
-     * Negative numbers may have 1s to the left of the 'size'th bit when the
-     * architecture has more bits than the requested operation i.e. 32 bit
-     * operation in a 64 bit architecture has the most significant 32 bits at 1
-     * for any and all negative numbers.
-     */
-    dest &= 1;
-    b    &= 1;
-    c    &= 1;
-
-    if ((dest == 0 && b == 1 && c == 1)
-        || (dest == 1 && b == 0 && c == 0)) {
-        return 1;
-    } else {
-        return 0;
-    }
-}
-target_ulong helper_overflow_add_flag(target_ulong dest, target_ulong b,
-                                      target_ulong c) {
-    return overflow_add_flag(dest, b, c, TARGET_LONG_BITS);
-}
-
-static inline target_ulong
 overflow_sub_flag(target_ulong dest, target_ulong b, target_ulong c,
                   uint8_t size)
 {
@@ -552,10 +521,6 @@ arc_status_regs_set(const struct arc_aux_reg_detail *aux_reg_detail,
 #ifdef TARGET_ARC64
 uint64_t helper_carry_add_flag32(uint64_t dest, uint64_t b, uint64_t c) {
     return carry_add_flag(dest, b, c, 32);
-}
-
-target_ulong helper_overflow_add_flag32(target_ulong dest, target_ulong b, target_ulong c) {
-    return overflow_add_flag(dest, b, c, 32);
 }
 
 target_ulong helper_overflow_sub_flag32(target_ulong dest, target_ulong b, target_ulong c) {

--- a/target/arc/semfunc-helper.h
+++ b/target/arc/semfunc-helper.h
@@ -171,35 +171,36 @@ void arc_gen_set_debug(const DisasCtxt *ctx, bool value);
 #define setBLINK(BLINK_ADDR) \
   tcg_gen_mov_tl(cpu_blink, BLINK_ADDR);
 
-#ifdef TARGET_ARC32
-
-#define Carry(R, A)             tcg_gen_shri_tl(R, A, 31);
-
-#endif
-
 
 #ifdef TARGET_ARC64
 
-#define Carry(R, A)             tcg_gen_shri_tl(R, A, 63);
 #define Carry32(R, A) \
-                                tcg_gen_shri_tl(R, A, 31); \
-                                tcg_gen_andi_tl(R, R, 0x1);
+                                  tcg_gen_shri_tl(R, A, 31); \
+                                  tcg_gen_andi_tl(R, R, 0x1);
+
+#define OverflowADD32(R, A, B, C) arc_gen_add_signed_overflow_tl(R, A, B, C, 32)
+
+#define CarryADD32(R, A, B, C)    gen_helper_carry_add_flag32(R, A, B, C)
+
+#define CarrySUB32(R, A, B, C)    gen_helper_carry_sub_flag32(R, A, B, C)
+
+#define OverflowSUB32(R, A, B, C) gen_helper_overflow_sub_flag32(R, A, B, C)
 
 #endif
 
-#define CarryADD(R, A, B, C)    gen_helper_carry_add_flag(R, A, B, C)
-#define OverflowADD(R, A, B, C) gen_helper_overflow_add_flag(R, A, B, C)
+#define Carry(R, A)               tcg_gen_shri_tl(R, A, TARGET_LONG_BITS - 1);
 
-#define CarryADD32(R, A, B, C)    gen_helper_carry_add_flag32(R, A, B, C)
-#define OverflowADD32(R, A, B, C) gen_helper_overflow_add_flag32(R, A, B, C)
+#define OverflowADD(R, A, B, C)   arc_gen_add_signed_overflow_tl(R, A, B, C, TARGET_LONG_BITS);
+
+#define CarryADD(R, A, B, C)    gen_helper_carry_add_flag(R, A, B, C)
+
+
 
 void arc_gen_sub_Cf(TCGv ret, TCGv dest, TCGv src1, TCGv src2);
 #define CarrySUB(R, A, B, C)    arc_gen_sub_Cf(R, A, B, C); \
                                 tcg_gen_setcondi_tl(TCG_COND_NE, R, R, 0)
 #define OverflowSUB(R, A, B, C) gen_helper_overflow_sub_flag(R, A, B, C)
 
-#define CarrySUB32(R, A, B, C)    gen_helper_carry_sub_flag32(R, A, B, C)
-#define OverflowSUB32(R, A, B, C) gen_helper_overflow_sub_flag32(R, A, B, C)
 
 
 #define unsignedLT(R, B, C)           tcg_gen_setcond_tl(TCG_COND_LTU, R, B, C)

--- a/target/arc/semfunc.h
+++ b/target/arc/semfunc.h
@@ -72,9 +72,23 @@ void arc_gen_vec_add16_w0_i64(TCGv_i64 d, TCGv_i64 a, TCGv_i64 b);
 void arc_gen_cmpl2_i64(TCGv_i64 ret, TCGv_i64 arg1,
                        unsigned int ofs, unsigned int len);
 
-/**
+/*
+ * @brief Verifies if an signed add resulted in an overflow. Only works with
+ * numbers smaller than the architecture size.
+ * @param overflow Set in case of overflow
+ * @param result The result of the addition
+ * @param op1 Operand of the add
+ * @param op2 Operand of the add
+ * @param operator_size Size of the add operands
+ */
+void arc_gen_add_signed_overflow_tl(TCGv overflow, TCGv result,
+                                    TCGv op1, TCGv op2, uint8_t operator_size);
+
+/*
  * @brief Verifies if a 64 bit signed add resulted in an overflow
- * @param overflow Is set to 1 or 0 on no overflow, or overflow, respectively
+ * This function is necessary because the _tl version cannot handle 64 bit
+ * computations in a 32 bit architecture
+ * @param overflow Set in case of overflow
  * @param result The result of the addition
  * @param op1 Operand of the add
  * @param op2 Operand of the add


### PR DESCRIPTION
Created arc_gen_add_signed_overflow_tl function to replace respective helpers.
The reason there needs to be both an _i64 version and a _tl one (or _i32) is because for 64 bit architectures, its perfectly fine to use TCGv (will become TCGv_i64) in the calculation of 32 bit overflow.
However, for 64 bit operations in a 32 bit architecture, TCGv_i32 can't be used and therefore an _i64 version is necessary (it is used directly in parts of the code not changed by this PR and does not appear in the diff).