### PR TITLE
CI: Add Github Action to build QEMU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches: [master]
+
+env:
+  BUILD_DIR: ${{ github.workspace }}/build
+
+jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          skip_after_successful_duplicate: 'true'
+
+  build:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+
+    name: Build QEMU for ${{ matrix.host.name }}
+    runs-on: ${{ matrix.host.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - { name: linux-x86_64, runner: ubuntu-20.04 }
+          - { name: macos-x86_64, runner: macos-11 }
+
+    steps:
+      - name: Set up build environment (macOS)
+        if: ${{ runner.os == 'macOS' }}
+        run: |
+          brew install ninja
+          echo "TAR=gtar" >> $GITHUB_ENV
+      - name: Set up build environment (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bison \
+            flex \
+            gettext \
+            help2man \
+            libncurses5-dev \
+            libtool-bin \
+            libtool-doc \
+            meson \
+            ninja-build \
+            tar \
+            texinfo
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow --tags --force
+
+      - name: Build QEMU
+        run: |
+          QEMU_TARGETS="arc-softmmu arc64-softmmu"
+          QEMU_FLAGS=""
+          # Target linux-user is only available on a Linux host
+          if [ "${{ matrix.host.name }}" == "linux-x86_64" ]; then
+            QEMU_TARGETS="${QEMU_TARGETS} arc-linux-user arc64-linux-user"
+          fi
+          ${{ github.workspace }}/configure \
+            ${QEMU_FLAGS} \
+            --target-list="${QEMU_TARGETS}" \
+            --prefix="${{ env.BUILD_DIR }}"
+          make -j $(nproc)
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: qemu-${{ matrix.host.name }}
+          path: |
+            ${{ env.BUILD_DIR }}/qemu-*arc*
+            !${{ env.BUILD_DIR }}/*.p
+        if: ${{ always() }}


### PR DESCRIPTION
This Action builds QEMU for two OS: Linux and macOS. The workflow runs for every pushed changes of every branch. Also, the workflow runs for pull requests, but it will be skipped with a link in the "pre_job" summary table to early ran workflow with the same Build Job.
As a result, you can download QEMU binaries from Artifacts.

