### PR TITLE
Fixed VADD2 LIMM not duplicated on ARC

### DIFF
--- a/target/arc/semfunc-v2.c
+++ b/target/arc/semfunc-v2.c
@@ -8668,17 +8668,18 @@ arc_gen_VMAC2HU(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
  * VADD: VADD2, VADD2H, VADD4H
  */
 
-#define ARC_GEN_BASE_I64(NAME, OP, SIZE)                                            \
-static void                                                                         \
-arc_gen_##NAME##_base_i64(DisasCtxt *ctx, TCGv_i64 dest, TCGv_i64 b, TCGv_i64 c,    \
-                       TCGv_i64 acc, bool set_n_flag,                               \
-                       ARC_GEN_EXTRACT_BITS_FUNC extract_bits,                      \
-                       ARC_GEN_OVERFLOW_DETECT_FUNC detect_overflow_i64)            \
-{                                                                                   \
-    ARC_GEN_VEC_FIRST_OPERAND(operand_##SIZE, i64, b);                              \
-    ARC_GEN_VEC_SECOND_OPERAND(operand_##SIZE, i64, c);                             \
-                                                                                    \
-    OP(dest, b, c);                                                                 \
+#define ARC_GEN_BASE_I64(NAME, OP, SIZE)                                    \
+static void                                                                 \
+arc_gen_##NAME##_base_i64(DisasCtxt *ctx,                                   \
+                        TCGv_i64 dest, TCGv_i64 b, TCGv_i64 c,              \
+                        TCGv_i64 acc, bool set_n_flag,                      \
+                        ARC_GEN_EXTRACT_BITS_FUNC extract_bits,             \
+                        ARC_GEN_OVERFLOW_DETECT_FUNC detect_overflow_i64)   \
+{                                                                           \
+  ARC_GEN_VEC_FIRST_OPERAND(operand_##SIZE, i64, b);                        \
+  ARC_GEN_VEC_SECOND_OPERAND(operand_##SIZE, i64, c);                       \
+                                                                            \
+  OP(dest, b, c);                                                           \
 }
 
 ARC_GEN_BASE_I64(vadd2, tcg_gen_vec_add32_i64,    32bit);
@@ -8694,13 +8695,13 @@ ARC_GEN_32BIT_INTERFACE(VADD2, PAIR, PAIR, PAIR, UNSIGNED, \
 int
 arc_gen_VADD2(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-    ARC_GEN_SEMFUNC_INIT();
+  ARC_GEN_SEMFUNC_INIT();
 
-    arc_autogen_base32_VADD2(ctx, dest, b, c);
+  arc_autogen_base32_VADD2(ctx, dest, b, c);
 
-    ARC_GEN_SEMFUNC_DEINIT();
+  ARC_GEN_SEMFUNC_DEINIT();
 
-    return DISAS_NEXT;
+  return DISAS_NEXT;
 }
 
 
@@ -8722,16 +8723,16 @@ VEC_ADD16_SUB16_I32_W0(sub, tcg_gen_vec_sub16_i32)
 int
 arc_gen_VADD2H(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-    ARC_GEN_SEMFUNC_INIT();
+  ARC_GEN_SEMFUNC_INIT();
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i32, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i32, c);
+  ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i32, b);
+  ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i32, c);
 
-    arc_gen_vec_add16_i32_w0(dest, b, c);
+  arc_gen_vec_add16_i32_w0(dest, b, c);
 
-    ARC_GEN_SEMFUNC_DEINIT();
+  ARC_GEN_SEMFUNC_DEINIT();
 
-    return DISAS_NEXT;
+  return DISAS_NEXT;
 }
 
 
@@ -8741,13 +8742,13 @@ ARC_GEN_32BIT_INTERFACE(VADD4H, PAIR, PAIR, PAIR, UNSIGNED, \
 int
 arc_gen_VADD4H(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-    ARC_GEN_SEMFUNC_INIT();
+  ARC_GEN_SEMFUNC_INIT();
 
-    arc_autogen_base32_VADD4H(ctx, dest, b, c);
+  arc_autogen_base32_VADD4H(ctx, dest, b, c);
 
-    ARC_GEN_SEMFUNC_DEINIT();
+  ARC_GEN_SEMFUNC_DEINIT();
 
-    return DISAS_NEXT;
+  return DISAS_NEXT;
 }
 
 /*
@@ -8760,28 +8761,28 @@ ARC_GEN_32BIT_INTERFACE(VSUB2, PAIR, PAIR, PAIR, UNSIGNED, \
 int
 arc_gen_VSUB2(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-    ARC_GEN_SEMFUNC_INIT();
+  ARC_GEN_SEMFUNC_INIT();
 
-    arc_autogen_base32_VSUB2(ctx, dest, b, c);
+  arc_autogen_base32_VSUB2(ctx, dest, b, c);
 
-    ARC_GEN_SEMFUNC_DEINIT();
+  ARC_GEN_SEMFUNC_DEINIT();
 
-    return DISAS_NEXT;
+  return DISAS_NEXT;
 }
 
 int
 arc_gen_VSUB2H(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-    ARC_GEN_SEMFUNC_INIT();
+  ARC_GEN_SEMFUNC_INIT();
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i32, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i32, c);
+  ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i32, b);
+  ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i32, c);
 
-    arc_gen_vec_sub16_i32_w0(dest, b, c);
+  arc_gen_vec_sub16_i32_w0(dest, b, c);
 
-    ARC_GEN_SEMFUNC_DEINIT();
+  ARC_GEN_SEMFUNC_DEINIT();
 
-    return DISAS_NEXT;
+  return DISAS_NEXT;
 }
 
 
@@ -8791,13 +8792,13 @@ ARC_GEN_32BIT_INTERFACE(VSUB4H, PAIR, PAIR, PAIR, UNSIGNED, \
 int
 arc_gen_VSUB4H(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-    ARC_GEN_SEMFUNC_INIT();
+  ARC_GEN_SEMFUNC_INIT();
 
-    arc_autogen_base32_VSUB4H(ctx, dest, b, c);
+  arc_autogen_base32_VSUB4H(ctx, dest, b, c);
 
-    ARC_GEN_SEMFUNC_DEINIT();
+  ARC_GEN_SEMFUNC_DEINIT();
 
-    return DISAS_NEXT;
+  return DISAS_NEXT;
 }
 
 /*

--- a/target/arc/semfunc-v2.c
+++ b/target/arc/semfunc-v2.c
@@ -8668,7 +8668,7 @@ arc_gen_VMAC2HU(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
  * VADD: VADD2, VADD2H, VADD4H
  */
 
-#define ARC_GEN_VADD2_BASE_I64(NAME, OP, SIZE)                                      \
+#define ARC_GEN_BASE_I64(NAME, OP, SIZE)                                            \
 static void                                                                         \
 arc_gen_##NAME##_base_i64(DisasCtxt *ctx, TCGv_i64 dest, TCGv_i64 b, TCGv_i64 c,    \
                        TCGv_i64 acc, bool set_n_flag,                               \
@@ -8681,8 +8681,11 @@ arc_gen_##NAME##_base_i64(DisasCtxt *ctx, TCGv_i64 dest, TCGv_i64 b, TCGv_i64 c,
     OP(dest, b, c);                                                                 \
 }
 
-ARC_GEN_VADD2_BASE_I64(vadd2, tcg_gen_vec_add32_i64,    32bit);
-ARC_GEN_VADD2_BASE_I64(vadd4h, tcg_gen_vec_add16_i64,   16bit);
+ARC_GEN_BASE_I64(vadd2, tcg_gen_vec_add32_i64,    32bit);
+ARC_GEN_BASE_I64(vadd4h, tcg_gen_vec_add16_i64,   16bit);
+ARC_GEN_BASE_I64(vsub2, tcg_gen_vec_sub32_i64,    32bit);
+ARC_GEN_BASE_I64(vsub4h, tcg_gen_vec_sub16_i64,   16bit);
+
 
 
 ARC_GEN_32BIT_INTERFACE(VADD2, PAIR, PAIR, PAIR, UNSIGNED, \
@@ -8714,6 +8717,7 @@ arc_gen_vec_##NAME##16_i32_w0(TCGv dest, TCGv b, TCGv c) \
 }
 
 VEC_ADD16_SUB16_I32_W0(add, tcg_gen_vec_add16_i32)
+VEC_ADD16_SUB16_I32_W0(sub, tcg_gen_vec_sub16_i32)
 
 int
 arc_gen_VADD2H(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
@@ -8750,57 +8754,50 @@ arc_gen_VADD4H(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
  * VSUB: VSUB2, VSUB2H, VSUB4H
  */
 
+ARC_GEN_32BIT_INTERFACE(VSUB2, PAIR, PAIR, PAIR, UNSIGNED, \
+                        arc_gen_vsub2_base_i64);
+
 int
 arc_gen_VSUB2(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-  TCGv cc_temp = tcg_temp_local_new();
-  TCGLabel *cc_done = gen_new_label();
+    ARC_GEN_SEMFUNC_INIT();
 
-  getCCFlag(cc_temp);
-  tcg_gen_brcondi_tl(TCG_COND_EQ, cc_temp, 0, cc_done);
+    arc_autogen_base32_VSUB2(ctx, dest, b, c);
 
-  arc_gen_vec_pair_i32(ctx, dest, b, c,
-                       tcg_gen_vec_sub32_i64);
+    ARC_GEN_SEMFUNC_DEINIT();
 
-  gen_set_label(cc_done);
-  tcg_temp_free(cc_temp);
-
-  return DISAS_NEXT;
+    return DISAS_NEXT;
 }
 
 int
 arc_gen_VSUB2H(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-  TCGv cc_temp = tcg_temp_local_new();
-  TCGLabel *cc_done = gen_new_label();
+    ARC_GEN_SEMFUNC_INIT();
 
-  getCCFlag(cc_temp);
-  tcg_gen_brcondi_tl(TCG_COND_EQ, cc_temp, 0, cc_done);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i32, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i32, c);
 
-  tcg_gen_vec_sub16_i32(dest, b, c);
+    arc_gen_vec_sub16_i32_w0(dest, b, c);
 
-  gen_set_label(cc_done);
-  tcg_temp_free(cc_temp);
+    ARC_GEN_SEMFUNC_DEINIT();
 
-  return DISAS_NEXT;
+    return DISAS_NEXT;
 }
+
+
+ARC_GEN_32BIT_INTERFACE(VSUB4H, PAIR, PAIR, PAIR, UNSIGNED, \
+                        arc_gen_vsub4h_base_i64);
 
 int
 arc_gen_VSUB4H(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)
 {
-  TCGv cc_temp = tcg_temp_local_new();
-  TCGLabel *cc_done = gen_new_label();
+    ARC_GEN_SEMFUNC_INIT();
 
-  getCCFlag(cc_temp);
-  tcg_gen_brcondi_tl(TCG_COND_EQ, cc_temp, 0, cc_done);
+    arc_autogen_base32_VSUB4H(ctx, dest, b, c);
 
-  arc_gen_vec_pair_i32(ctx, dest, b, c,
-                       tcg_gen_vec_sub16_i64);
+    ARC_GEN_SEMFUNC_DEINIT();
 
-  gen_set_label(cc_done);
-  tcg_temp_free(cc_temp);
-
-  return DISAS_NEXT;
+    return DISAS_NEXT;
 }
 
 /*

--- a/target/arc/semfunc-v3.c
+++ b/target/arc/semfunc-v3.c
@@ -14309,20 +14309,20 @@ arc_gen_vec_##NAME##16_i64_w0(TCGv dest, TCGv b, TCGv c) \
 VEC_ADD16_SUB16_I64_W0(add, tcg_gen_vec_add16_i64)
 VEC_ADD16_SUB16_I64_W0(sub, tcg_gen_vec_sub16_i64)
 
-#define VEC_ADD_SUB(INSN, OP, FIELD_SIZE)                 \
-int                                                       \
-arc_gen_##INSN(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c) \
-{                                                         \
-    ARC_GEN_SEMFUNC_INIT();                               \
-                                                          \
-    ARC_GEN_VEC_FIRST_OPERAND(operand_##FIELD_SIZE, b);   \
-    ARC_GEN_VEC_SECOND_OPERAND(operand_##FIELD_SIZE, c);  \
-                                                          \
-    /* Instruction code */                                \
-    OP(dest, b, c);                                       \
-                                                          \
-    ARC_GEN_SEMFUNC_DEINIT();                             \
-    return DISAS_NEXT;                                    \
+#define VEC_ADD_SUB(INSN, OP, FIELD_SIZE)                     \
+int                                                           \
+arc_gen_##INSN(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)     \
+{                                                             \
+    ARC_GEN_SEMFUNC_INIT();                                   \
+                                                              \
+    ARC_GEN_VEC_FIRST_OPERAND(operand_##FIELD_SIZE, i64, b);  \
+    ARC_GEN_VEC_SECOND_OPERAND(operand_##FIELD_SIZE, i64, c); \
+                                                              \
+    /* Instruction code */                                    \
+    OP(dest, b, c);                                           \
+                                                              \
+    ARC_GEN_SEMFUNC_DEINIT();                                 \
+    return DISAS_NEXT;                                        \
 }
 
 VEC_ADD_SUB(VADD2,  tcg_gen_vec_add32_i64,    32bit)
@@ -14365,20 +14365,20 @@ arc_gen_vmac2_op(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c,
   tcg_temp_free(t4);
 }
 
-#define ARC_GEN_VEC_MAC2H(INSN, OP, FIELD_SIZE)             \
-int                                                         \
-arc_gen_##INSN(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)   \
-{                                                           \
-    ARC_GEN_SEMFUNC_INIT();                                 \
-                                                            \
-    ARC_GEN_VEC_FIRST_OPERAND(operand_##FIELD_SIZE, b);     \
-    ARC_GEN_VEC_SECOND_OPERAND(operand_##FIELD_SIZE, c);    \
-                                                            \
-    arc_gen_vmac2_op(ctx, dest, b, c, OP);                  \
-                                                            \
-    ARC_GEN_SEMFUNC_DEINIT();                               \
-                                                            \
-    return DISAS_NEXT;                                      \
+#define ARC_GEN_VEC_MAC2H(INSN, OP, FIELD_SIZE)               \
+int                                                           \
+arc_gen_##INSN(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)     \
+{                                                             \
+    ARC_GEN_SEMFUNC_INIT();                                   \
+                                                              \
+    ARC_GEN_VEC_FIRST_OPERAND(operand_##FIELD_SIZE, i64, b);  \
+    ARC_GEN_VEC_SECOND_OPERAND(operand_##FIELD_SIZE, i64, c); \
+                                                              \
+    arc_gen_vmac2_op(ctx, dest, b, c, OP);                    \
+                                                              \
+    ARC_GEN_SEMFUNC_DEINIT();                                 \
+                                                              \
+    return DISAS_NEXT;                                        \
 }  
 
 ARC_GEN_VEC_MAC2H(VMAC2H, tcg_gen_sextract_tl, 16bit)
@@ -14391,8 +14391,8 @@ arc_gen_##INSN(DisasCtxt *ctx, TCGv dest, TCGv b, TCGv c)     \
     TCGv t1;                                                  \
     ARC_GEN_SEMFUNC_INIT();                                   \
                                                               \
-    ARC_GEN_VEC_FIRST_OPERAND(operand_##FIELD_SIZE, b);       \
-    ARC_GEN_VEC_SECOND_OPERAND(operand_##FIELD_SIZE, c);      \
+    ARC_GEN_VEC_FIRST_OPERAND(operand_##FIELD_SIZE, i64, b);  \
+    ARC_GEN_VEC_SECOND_OPERAND(operand_##FIELD_SIZE, i64, c); \
                                                               \
     t1 = tcg_temp_new();                                      \
     ARC_GEN_CMPL2_##FIELD##_I64(t1, c);                       \

--- a/target/arc/semfunc.c
+++ b/target/arc/semfunc.c
@@ -190,6 +190,7 @@ arc_gen_mac_check_fflags(DisasCtxt *ctx, TCGv_i64 result, TCGv_i64 operand_1,
     }
 }
 
+
 void
 arc_gen_qmach_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
                        TCGv_i64 acc, bool set_n_flag,
@@ -208,8 +209,8 @@ arc_gen_qmach_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
 
     /* Instruction code */
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, c);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i64, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i64, c);
 
     extract_bits(b_h0, b, 0, 16);
     extract_bits(b_h1, b, 16, 16);
@@ -273,8 +274,8 @@ arc_gen_dmacwh_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
 
     /* Instruction code */
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_32bit, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, c);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_32bit, i64, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i64, c);
 
     extract_bits(b_w0, b, 0, 32);
     extract_bits(b_w1, b, 32, 32);
@@ -323,8 +324,8 @@ arc_gen_dmach_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
 
     /* Instruction code */
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, c);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i64, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i64, c);
 
     extract_bits(b_h0, b, 0, 16);
     extract_bits(b_h1, b, 16, 16);
@@ -411,8 +412,8 @@ arc_gen_dmpyh_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
 
     /* Instruction code */
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, c);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i64, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i64, c);
 
     extract_bits(b_h0, b, 0, 16);
     extract_bits(b_h1, b, 16, 16);
@@ -460,8 +461,8 @@ arc_gen_qmpyh_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
 
     /* Instruction code */
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, c);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i64, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i64, c);
 
     extract_bits(b_h0, b, 0, 16);
     extract_bits(b_h1, b, 16, 16);
@@ -522,8 +523,8 @@ arc_gen_dmpywh_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
 
     /* Instruction code */
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_32bit, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, c);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_32bit, i64, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i64, c);
 
     extract_bits(b_w0, b, 0, 32);
     extract_bits(b_w1, b, 32, 32);
@@ -570,8 +571,8 @@ arc_gen_vmpy2h_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
 
     /* Instruction code */
 
-    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, c);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_16bit, i64, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_16bit, i64, c);
 
     extract_bits(b_h0, b, 0, 16);
     extract_bits(b_h1, b, 16, 16);
@@ -608,8 +609,8 @@ arc_gen_mpyd_base_i64(DisasCtxt *ctx, TCGv_i64 a, TCGv_i64 b, TCGv_i64 c,
                         ARC_GEN_OVERFLOW_DETECT_FUNC detect_overflow_i64)
 {
     /* Instruction code */
-    ARC_GEN_VEC_FIRST_OPERAND(operand_64bit, b);
-    ARC_GEN_VEC_SECOND_OPERAND(operand_64bit, c);
+    ARC_GEN_VEC_FIRST_OPERAND(operand_64bit, i64, b);
+    ARC_GEN_VEC_SECOND_OPERAND(operand_64bit, i64, c);
 
     extract_bits(b, b, 0, 32);
     extract_bits(c, c, 0, 32);

--- a/target/arc/semfunc.h
+++ b/target/arc/semfunc.h
@@ -161,34 +161,34 @@ arc_gen_set_operand_16bit_vec_const(DisasCtxt *ctx, operand_t *operand);
 /*
  * Generate code to handle the first operand (TCG_OPERAND) in a vector
  * operation to quadriplicate/duplicatie its' value based on the provided vector
- * operand size (OP_SIZE)
  */
-#define ARC_GEN_VEC_FIRST_OPERAND(OP_SIZE, TCG_OPERAND)                 \
-    do {                                                                \
-        operand_t *operand_1 = &(ctx->insn.operands[1]);                \
-        if (!(operand_1->type & ARC_OPERAND_IR)) {                      \
-            arc_gen_set_ ## OP_SIZE ## _vec_const(ctx, operand_1);      \
-            tcg_gen_movi_i64(TCG_OPERAND, operand_1->value);            \
-        }                                                               \
+#define ARC_GEN_VEC_FIRST_OPERAND(OPERAND_SIZE, OPERATION_SIZE,             \
+                                TCG_OPERAND)                                \
+    do {                                                                    \
+        operand_t *operand_1 = &(ctx->insn.operands[1]);                    \
+        if (!(operand_1->type & ARC_OPERAND_IR)) {                          \
+            arc_gen_set_ ## OPERAND_SIZE ## _vec_const(ctx, operand_1);     \
+            tcg_gen_movi_##OPERATION_SIZE(TCG_OPERAND, operand_1->value);   \
+        }                                                                   \
     } while(0)
 
 /*
  * Generate code to handle the second operand (TCG_OPERAND) in a vector
  * operation to quadriplicate/duplicatie its' value based on the provided vector
- * operand size (OP_SIZE).
  */
-#define ARC_GEN_VEC_SECOND_OPERAND(OP_SIZE, TCG_OPERAND)                \
-    do {                                                                \
-        operand_t *operand_2 = &(ctx->insn.operands[2]);                \
-        if (!(operand_2->type & ARC_OPERAND_IR)) {                      \
-            if (operand_2->type & ARC_OPERAND_LIMM &&                   \
-                operand_2->type & ARC_OPERAND_DUPLICATE){               \
-                operand_2->value = ctx->insn.operands[1].value;         \
-            } else {                                                    \
-                arc_gen_set_ ## OP_SIZE ## _vec_const(ctx, operand_2);  \
-            }                                                           \
-            tcg_gen_movi_i64(TCG_OPERAND, operand_2->value);            \
-        }                                                               \
+#define ARC_GEN_VEC_SECOND_OPERAND(OPERAND_SIZE, OPERATION_SIZE,            \
+                                TCG_OPERAND)                                \
+    do {                                                                    \
+        operand_t *operand_2 = &(ctx->insn.operands[2]);                    \
+        if (!(operand_2->type & ARC_OPERAND_IR)) {                          \
+            if (operand_2->type & ARC_OPERAND_LIMM &&                       \
+                operand_2->type & ARC_OPERAND_DUPLICATE){                   \
+                operand_2->value = ctx->insn.operands[1].value;             \
+            } else {                                                        \
+                arc_gen_set_ ## OPERAND_SIZE ## _vec_const(ctx, operand_2); \
+            }                                                               \
+            tcg_gen_movi_ ##OPERATION_SIZE(TCG_OPERAND, operand_2->value);  \
+        }                                                                   \
     } while(0)
 
 /**


### PR DESCRIPTION
When present in the form 'vadd2 a, LIMM, b', LIMM is now duplicated rather than extended.