### PR TITLE
[CI] Add pkg-config binary to macOS build environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Set up build environment (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: |
-          brew install ninja
+          brew install \
+            ninja \
+            pkg-config
           echo "TAR=gtar" >> $GITHUB_ENV
       - name: Set up build environment (Linux)
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
There is failed CI action in branch https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/tree/bruno_Added_brk_s_mapping that can't build QEMU for macOS, because **pkg-config** binary not found. This PR fixes it.