### PR TITLE
Slight improvement of interrupt code legibility and interrupt priority check fix

### DIFF
--- a/target/arc/irq.h
+++ b/target/arc/irq.h
@@ -30,6 +30,11 @@ void switchSP(CPUARCState *);
 void arc_initializeIRQ(ARCCPU *);
 void arc_resetIRQ(ARCCPU *);
 
+/* Interrupt vectors start after exception vectors */
+#define NR_OF_EXCEPTIONS  16
+#define TIMER0_IRQ 16
+#define TIMER1_IRQ 17
+
 #if defined(TARGET_ARC32)
 #define OFFSET_FOR_VECTOR(VECNO) (VECNO << 2)
 #elif defined(TARGET_ARC64)


### PR DESCRIPTION
Swapped magic number 16 with start of IRQ vectors (start after exceptions).
Corrected lower bound value of priority check loop to start at 0 instead of 16, applying the correction that accounts for exception vectors in the access to irq_bank (other option would be to add 16 to number_of_interrupts in the loop)

cfg.number_of_interrupts does not include the first 16 exceptions. This can be inferred by it's default value of 240 in https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/blob/bruno_removed_mmupagesize_from_hs5x/target/arc/cpu.c#L91 and its' use throughout the code, like in interrupt initialization here https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/blob/bruno_removed_mmupagesize_from_hs5x/hw/arc/pic_cpu.c#L106