### PR TITLE
Completed issue #104 by limiting configuration option ranges

### DIFF
--- a/target/arc/mmu-v6.c
+++ b/target/arc/mmu-v6.c
@@ -713,7 +713,12 @@ void arc_mmu_init_v6(CPUARCState *env)
         }
         break;
     case ARC_OPCODE_ARC32:
-        mmu_v6_version = &mmuv6_info[MMUV6_32_4K];
+        if (cpu->cfg.mmuv6_version == NULL ||
+            !g_strcmp0(cpu->cfg.mmuv6_version, "32_4k")) {
+            mmu_v6_version = &mmuv6_info[MMUV6_32_4K];
+        } else {
+            assert("MMUV6 mmuv6_version is invalid !!!" == 0);
+        }
         break;
     default:
         assert("Should not happen!!!" == 0);

--- a/target/arc/mmu.c
+++ b/target/arc/mmu.c
@@ -720,9 +720,7 @@ void arc_mmu_init_v3(CPUARCState *env)
     env->mmu.v3.scratch_data0 = 0;
 
     mmu_v3_page_size = cpu->cfg.mmu_page_size_sel0;
-    if(mmu_v3_page_size < 12 || mmu_v3_page_size > 24) {
-	assert("mmu-pagesize0 should be between 12 and 24." == 0);
-    }
+    assert(mmu_v3_page_size == 13);
 
     memset(env->mmu.v3.nTLB, 0, sizeof(env->mmu.v3.nTLB));
 }


### PR DESCRIPTION
As issue https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/104 states, in order to prevent user confusion when setting certain mmu configurations, limited those configurations' ranges to the ones that are tested and expected/available