### PR TITLE
Fixed helper not recovering from recoverable load segfault

### DIFF
--- a/target/arc/arconnect.h
+++ b/target/arc/arconnect.h
@@ -28,9 +28,6 @@ struct lpa_lf_entry {
     QemuMutex mutex;
     target_ulong lpa_lf;
     uint64_t read_value;
-#ifdef TARGET_ARC32
-    uint64_t read_value1;
-#endif
 };
 
 struct arc_arcconnect_info {

--- a/target/arc/cpu.c
+++ b/target/arc/cpu.c
@@ -447,7 +447,10 @@ static struct TCGCPUOps arc_tcg_ops = {
     .initialize = arc_translate_init,
     .synchronize_from_tb = arc_cpu_synchronize_from_tb,
 
-#ifndef CONFIG_USER_ONLY
+#ifdef CONFIG_USER_ONLY
+    .record_sigsegv = arc_cpu_record_sigsegv,
+    .record_sigbus = arc_cpu_record_sigbus,
+#else
     .tlb_fill = arc_cpu_tlb_fill,
     .cpu_exec_interrupt = arc_cpu_exec_interrupt,
     .do_interrupt = arc_cpu_do_interrupt,

--- a/target/arc/cpu.h
+++ b/target/arc/cpu.h
@@ -465,6 +465,22 @@ static inline void cpu_get_tb_cpu_state(CPUARCState *env, target_ulong *pc,
 #define IS_ARCV3(CPU) \
   ((cpu->family & ARC_OPCODE_V3_ALL) != 0)
 
+/*
+ * @brief vCPU is about to raise SIGSEV. Perform required cleanup
+ * At the moment, this just means unlocking llock/scond mutexes and clearing LF
+ */
+void arc_cpu_record_sigsegv(CPUState *cs, vaddr addr,
+                            MMUAccessType access_type,
+                            bool maperr, uintptr_t ra);
+
+/*
+ * @brief vCPU is about to raise SIGBUS. Perform required cleanup
+ * At the moment, this just means unlocking llock/scond mutexes and clearing LF
+ */
+void arc_cpu_record_sigbus(CPUState *cs, vaddr addr,
+                            MMUAccessType access_type,
+                            uintptr_t ra);
+
 void arc_translate_init(void);
 
 void arc_cpu_list(void);


### PR DESCRIPTION
As per issue https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/166, user mode llock load/store exceptions are currently not recoverable, even if there is a proper handler for them.

As per the issue, this was detected via failure of the g++.dg/ext/sync-4.C gcc dejaGNU tests when running qemu usermode.

To fix this, we simply need to use the _ra variants inside the llock/scond TCG helpers, and pass the current PC value via GETPC().
An important note is that "env->arconnect.lpa_lf = entry;" is pulled before the relevant load, so it should never be NULL.

However, as the llock/scond variants are guarded with mutex locks, there is a deadlock if we retry any llock/scond after such an exception.

To prevent this, we ask QEMU to run a callback for the relevant exceptions. 
QEMU provides .record_sigsegv and .record_sigbus TCGCPUOps for this specific purpose.

In these callbacks, all we need to do is check if there is a lock and respective LF flag, and if so unlock and clear them.