### PR TITLE
"virt" machine command-line configurability

### DIFF
--- a/hw/arc/arc_virt.c
+++ b/hw/arc/arc_virt.c
@@ -27,6 +27,8 @@
  * their name, parent structure, name inside parent structure, and default value
  */
 static Property arc_virt_properties[] = {
+    /* Default value kept at 0x8000_0000 for compatibility reasons */
+    DEFINE_PROP_UINT64("ram-start", ARCVirtMachineState, ram_start, 0x80000000),
     DEFINE_PROP_END_OF_LIST(),
 };
 

--- a/hw/arc/arc_virt.c
+++ b/hw/arc/arc_virt.c
@@ -1,0 +1,54 @@
+/*
+ * QEMU ARC CPU
+ *
+ * Copyright (c) 2023 Synopsys Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+#include "qemu/osdep.h"
+#include "hw/boards.h"
+#include "hw/arc/virt.h"
+
+/*
+ * Available command line properties, defined by:
+ * their name, parent structure, name inside parent structure, and default value
+ */
+static Property arc_virt_properties[] = {
+    DEFINE_PROP_END_OF_LIST(),
+};
+
+/* Definition of parent ARC virtual machine */
+static void arc_virt_machine_class_init(ObjectClass *oc, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(oc);
+
+    device_class_set_props(dc, arc_virt_properties);
+}
+
+static const TypeInfo arc_virt_machine_info = {
+    .name          = TYPE_ARC_VIRT_MACHINE,
+    .parent        = TYPE_MACHINE,
+    .abstract      = true,
+    .instance_size = sizeof(ARCVirtMachineState),
+    .class_size    = sizeof(ARCVirtMachineClass),
+    .class_init    = arc_virt_machine_class_init,
+};
+
+static void machvirt_machine_init(void)
+{
+    type_register_static(&arc_virt_machine_info);
+}
+type_init(machvirt_machine_init);

--- a/hw/arc/meson.build
+++ b/hw/arc/meson.build
@@ -3,6 +3,7 @@ arc_ss.add(files(
   'arc_sim.c',
   'pic_cpu.c',
   'boot.c',
+  'arc_virt.c',
 ))
 arc_ss.add(when: 'CONFIG_ARC_VIRT', if_true: files('virt.c'))
 

--- a/hw/arc/virt.c
+++ b/hw/arc/virt.c
@@ -25,6 +25,7 @@
 #include "hw/arc/cpudevs.h"
 #include "hw/pci-host/gpex.h"
 #include "hw/sysbus.h"
+#include "hw/arc/virt.h"
 
 #define VIRT_RAM_BASE      0x80000000
 #define VIRT_IO_BASE       0xf0000000
@@ -186,8 +187,25 @@ static void virt_machine_init(MachineClass *mc)
     mc->default_ram_size = 2 * GiB;
 }
 
-DEFINE_MACHINE("virt", virt_machine_init)
+static void virt_machine_init_class_init(ObjectClass *oc, void *data)
+{
+    MachineClass *mc = MACHINE_CLASS(oc);
 
+    virt_machine_init(mc);
+}
+
+static const TypeInfo virt_machine_init_typeinfo = {
+    .name = MACHINE_TYPE_NAME("virt"),
+    .parent = TYPE_ARC_VIRT_MACHINE,
+    .class_init = virt_machine_init_class_init,
+};
+
+static void virt_machine_init_register_types(void)
+{
+    type_register_static(&virt_machine_init_typeinfo);
+}
+
+type_init(virt_machine_init_register_types);
 
 /*-*-indent-tabs-mode:nil;tab-width:4;indent-line-function:'insert-tab'-*-*/
 /* vim: set ts=4 sw=4 et: */

--- a/hw/arc/virt.c
+++ b/hw/arc/virt.c
@@ -27,7 +27,6 @@
 #include "hw/sysbus.h"
 #include "hw/arc/virt.h"
 
-#define VIRT_RAM_BASE      0x80000000
 #define VIRT_IO_BASE       0xf0000000
 #define VIRT_IO_SIZE       0x10000000
 
@@ -110,6 +109,7 @@ static void create_pcie(ARCCPU *cpu)
 
 static void virt_init(MachineState *machine)
 {
+    ARCVirtMachineState *vms = ARC_VIRT_MACHINE(machine);
     static struct arc_boot_info boot_info;
     unsigned int smp_cpus = machine->smp.cpus;
     MemoryRegion *system_memory = get_system_memory();
@@ -119,7 +119,7 @@ static void virt_init(MachineState *machine)
     ARCCPU *cpu = NULL;
     int n;
 
-    boot_info.ram_start = VIRT_RAM_BASE;
+    boot_info.ram_start = vms->ram_start;
     boot_info.ram_size = machine->ram_size;
     boot_info.kernel_filename = machine->kernel_filename;
     boot_info.kernel_cmdline = machine->kernel_cmdline;
@@ -146,9 +146,9 @@ static void virt_init(MachineState *machine)
 
     /* Init system DDR */
     system_ram = g_new(MemoryRegion, 1);
-    memory_region_init_ram(system_ram, NULL, "arc.ram", machine->ram_size,
+    memory_region_init_ram(system_ram, NULL, "arc.ram", boot_info.ram_size,
                            &error_fatal);
-    memory_region_add_subregion(system_memory, VIRT_RAM_BASE, system_ram);
+    memory_region_add_subregion(system_memory, boot_info.ram_start, system_ram);
 
     system_ram0 = g_new(MemoryRegion, 1);
     memory_region_init_ram(system_ram0, NULL, "arc.ram0", 0x1000000,

--- a/include/hw/arc/virt.h
+++ b/include/hw/arc/virt.h
@@ -1,0 +1,53 @@
+/*
+ * QEMU ARC CPU
+ *
+ * Copyright (c) 2023 Synopsys Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+
+#ifndef HW_ARC_VIRT_H
+#define HW_ARC_VIRT_H
+
+#include "qom/object.h"
+#include "hw/qdev-properties.h"
+
+/* Parent virtual machine class data */
+struct ARCVirtMachineClass {
+    MachineClass parent;
+};
+
+/*
+ * Parent virtual machine instance data
+ * Access via:
+ * ARCVirtMachineState *vms = ARC_VIRT_MACHINE(machine_inst);
+ * Where machine_inst is a pointer to any type of child instance (i.e. Object*
+ * or MachineState*)
+ */
+struct ARCVirtMachineState {
+    MachineState parent;
+};
+
+/* Define the type name for the parent virtual machine */
+#define TYPE_ARC_VIRT_MACHINE   MACHINE_TYPE_NAME("arc-virt-parent")
+
+/*
+ * Instantiate an object ARC_VIRT_MACHINE with ARCVirtMachineState as instance
+ * data and ARCVirtMachineClass as class data
+ */
+OBJECT_DECLARE_TYPE(ARCVirtMachineState, ARCVirtMachineClass, ARC_VIRT_MACHINE)
+
+
+#endif /* !HW_ARC_VIRT_H */

--- a/include/hw/arc/virt.h
+++ b/include/hw/arc/virt.h
@@ -38,6 +38,7 @@ struct ARCVirtMachineClass {
  */
 struct ARCVirtMachineState {
     MachineState parent;
+    uint64_t ram_start;
 };
 
 /* Define the type name for the parent virtual machine */


### PR DESCRIPTION
Create a new, abstract virtual machine to centralize command line option handling.

Change the "virt" machine from being a "pure machine" to inherit from this new abstract machine.

Add ram-start as an option to the parent machine, and make "virt" use it during initialization.

These changes come about from the request made in https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/171 which requires us to either add support for configuring machines, or permanently change the ram_start address value. The flexibility of the former made it the chosen solution.

To change any machine option, instead of running with the usual: `-machine virt`/`-M virt`, use something like `-machine virt,ram-start=0`/`-M virt,ram-start=0`

Note:
The default value for "ram-start"  is the previous constant (0x80000000) so as not to disrupt currently automated usages of qemu (i.e. testsuite configurations)

 --  edit --

Note2:
The reason the virt machine was adapted but not arc-sim is because:
1) Unlike arc-sim, virt has ram starting at not 0, which means it is the one issue https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/171 is referring to (as currently we only have 2 machines)
2) For a reason that currently eludes me, arc-sim and virt have different "ram-start" values so I cannot pick a single default for both
