### PR TITLE
ebpf: replace deprecated bpf_program__set_socket_filter

### DIFF
--- a/ebpf/ebpf_rss.c
+++ b/ebpf/ebpf_rss.c
@@ -49,7 +49,7 @@ bool ebpf_rss_load(struct EBPFRSSContext *ctx)
         goto error;
     }
 
-    bpf_program__set_socket_filter(rss_bpf_ctx->progs.tun_rss_steering_prog);
+    bpf_program__set_type(rss_bpf_ctx->progs.tun_rss_steering_prog, BPF_PROG_TYPE_SOCKET_FILTER);
 
     if (rss_bpf__load(rss_bpf_ctx)) {
         trace_ebpf_error("eBPF RSS", "can not load RSS program");


### PR DESCRIPTION
Adding this commit so more recent Linux distros can compile QEMU without needing outdated library versions.
```
bpf_program__set_<TYPE> functions have been deprecated since libbpf 0.8.

Replace with the equivalent bpf_program__set_type call to avoid a deprecation warning.

Reviewed-by: Zhang Chen <chen.zhang@intel.com>
```