### PR TITLE
Decoder: Fixed short limm decoding check for HS5X

### DIFF
--- a/target/arc/decoder-v3.c
+++ b/target/arc/decoder-v3.c
@@ -155,7 +155,7 @@ load_insninfo_if_valid_v3(uint64_t insn,
 
         /* Check for (short) LIMM indicator.  If it is there, then
            make sure we pick the right format.  */
-        slimmind = (isa_mask & (ARC_OPCODE_ARCV2 | ARC_OPCODE_ARC64)) ?
+        slimmind = (isa_mask & ARC_OPCODE_V2_V3) ?
           REG_LIMM_S : REG_LIMM;
         if (operand->flags & ARC_OPERAND_IR
             && !(operand->flags & ARC_OPERAND_LIMM))


### PR DESCRIPTION
Fix for https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/191

Decoder was ignoring shimm for hs5x, which was leading to wrong encodings being chosen. 

As the picked encodings were mostly matching, this didn't cause problems thus far, but being wrong, they could eventually lead to problems.