### PR TITLE
Encoding: Added brk_s mapping into HALT semfunc

### DIFF
--- a/target/arc/semfunc-mapping.def
+++ b/target/arc/semfunc-mapping.def
@@ -335,6 +335,7 @@ MAPPING(dmachu, DMACHU, 3, 0, 1, 2)
 MAPPING(dmach, DMACH, 3, 0, 1, 2)
 
 MAPPING(brk, HALT, 0)
+MAPPING(brk_s, HALT, 0)
 
 /* Long instruction */
 


### PR DESCRIPTION
brk_s is supported in hs6x but the semfunc mapping is missing