### PR TITLE
TCG: Fixed wrong return of semfunc (NORETURN)

### DIFF
--- a/target/arc/semfunc-v2.c
+++ b/target/arc/semfunc-v2.c
@@ -6955,8 +6955,6 @@ arc_gen_SCONDD(DisasCtxt *ctx, TCGv addr, TCGv value)
 int
 arc_gen_DMB (DisasCtxt *ctx, TCGv a)
 {
-  int ret = DISAS_UPDATE;
-
   TCGBar bar = 0;
   switch(ctx->insn.operands[0].value & 7) {
     case 1:
@@ -6971,7 +6969,7 @@ arc_gen_DMB (DisasCtxt *ctx, TCGv a)
   }
   tcg_gen_mb(bar);
 
-  return ret;
+  return DISAS_NORETURN;
 }
 
 

--- a/target/arc/semfunc-v3.c
+++ b/target/arc/semfunc-v3.c
@@ -7231,8 +7231,6 @@ arc_gen_SCONDL(DisasCtxt *ctx, TCGv addr, TCGv value)
 int
 arc_gen_DMB (DisasCtxt *ctx, TCGv a)
 {
-  int ret = DISAS_NEXT;
-
   TCGBar bar = 0;
   switch(ctx->insn.operands[0].value & 7) {
     case 1:
@@ -7247,7 +7245,7 @@ arc_gen_DMB (DisasCtxt *ctx, TCGv a)
   }
   tcg_gen_mb(bar);
 
-  return ret;
+  return DISAS_NORETURN;
 }
 
 

--- a/target/arc/translate.c
+++ b/target/arc/translate.c
@@ -818,11 +818,10 @@ arc_gen_DSYNC(DisasCtxt *ctx)
 int
 arc_gen_HALT(DisasCtxt *ctx)
 {
-    int ret = DISAS_NEXT;
     TCGv npc = tcg_const_local_tl(ctx->cpc);
     gen_helper_halt(cpu_env, npc);
     tcg_temp_free(npc);
-    return ret;
+    return DISAS_NORETURN;
 }
 
 #ifdef TARGET_ARC64
@@ -1200,7 +1199,7 @@ arc_gen_SWI(DisasCtxt *ctx, TCGv a)
 
     tcg_temp_free(tcg_index);
     tcg_temp_free(tcg_cause);
-    return DISAS_NEXT;
+    return DISAS_NORETURN;
 }
 int
 arc_gen_TRAP(DisasCtxt *ctx, TCGv a)
@@ -1327,7 +1326,7 @@ arc_gen_SLEEP(DisasCtxt *ctx, TCGv a)
 {
     /* FIXME: Add check for kernel mode. */
     arc_gen_sleep(ctx, a);
-    return DISAS_NEXT;
+    return DISAS_NORETURN;
 }
 
 /*
@@ -1353,7 +1352,7 @@ arc_gen_WEVT(DisasCtxt *ctx, TCGv c)
 
     arc_gen_sleep(ctx, c);
 
-    return DISAS_NEXT;
+    return DISAS_NORETURN;
 }
 
 /*
@@ -1395,7 +1394,7 @@ arc_gen_WLFC(DisasCtxt *ctx, TCGv c)
     gen_set_label(dont_stop);
     tcg_temp_free(lf_set);
 
-    return DISAS_NEXT;
+    return DISAS_NORETURN;
 }
 
 /* Given a CTX, generate the relevant TCG code for the given opcode. */


### PR DESCRIPTION
The instructions HALT/DMB/SWI/WEVT/WLFC/SLEEP should end a TB with DISAS_NORETURN instead of DISAS_NEXT.