### PR TITLE
TCG: Add exception for ilink access in usermode

### DIFF
--- a/tests/tcg/arc/generic/check_ilink_usermode.S
+++ b/tests/tcg/arc/generic/check_ilink_usermode.S
@@ -1,0 +1,57 @@
+.include "macros.inc"
+
+.data
+.align 4
+return_addr:
+    .word @fail
+
+.text
+    .align 4
+    .global EV_PrivilegeV
+    .type EV_PrivilegeV, @function
+EV_PrivilegeV:
+    ld  r0, [@return_addr]
+    sr  r0, [eret]
+    rtie
+
+start
+
+; Test 1
+; ilink change in kernel mode (initial mode) is allowed
+; CPU exception not triggered
+mov r0, @fail
+st  r0, [@return_addr]
+
+mov ilink, 0x91
+
+
+; Test 2
+; ilink change in user mode not allowed
+; CPU exception is triggered
+mov r0, @success
+st  r0, [@return_addr]
+
+enter_user_mode @usermode
+
+j @fail
+
+usermode:
+    mov ilink, 0x91
+    j @fail
+
+success:
+    mov r0, 0xdecaf
+    print "[PASS] "
+    b @1f
+
+; If a test fails, it jumps here. Although, for the sake of uniformity,
+; the printed output does not say much about which test case failed,
+; one can uncomment the print_number line below or set a breakpoint
+; here to check the R0 register for the test case number.
+fail:
+  mov r0, 0xbadc0ffe
+  print "[FAIL] "
+1:
+    print " no ilink in usermode\n"
+
+end

--- a/tests/tcg/arc64/check_ilink_usermode.S
+++ b/tests/tcg/arc64/check_ilink_usermode.S
@@ -1,0 +1,57 @@
+.include "macros.inc"
+
+.data
+.align 4
+return_addr:
+    .word @fail
+
+.text
+    .align 4
+    .global EV_PrivilegeV
+    .type EV_PrivilegeV, @function
+EV_PrivilegeV:
+    ld  r0, [@return_addr]
+    sr  r0, [eret]
+    rtie
+
+start
+
+; Test 1
+; ilink change in kernel mode (initial mode) is allowed
+; CPU exception not triggered
+mov r0, @fail
+st  r0, [@return_addr]
+
+mov ilink, 0x91
+
+
+; Test 2
+; ilink change in user mode not allowed
+; CPU exception is triggered
+mov r0, @success
+st  r0, [@return_addr]
+
+enter_user_mode @usermode
+
+j @fail
+
+usermode:
+    mov ilink, 0x91
+    j @fail
+
+success:
+    mov r0, 0xdecaf
+    print "[PASS] "
+    b @1f
+
+; If a test fails, it jumps here. Although, for the sake of uniformity,
+; the printed output does not say much about which test case failed,
+; one can uncomment the print_number line below or set a breakpoint
+; here to check the R0 register for the test case number.
+fail:
+    mov r0, 0xbadc0ffe
+    print "[FAIL] "
+1:
+    print " ilink in usermode\n"
+
+end


### PR DESCRIPTION
Add basic check for ilink access in usermode, and respective TCG tests.

Closes https://github.com/foss-for-synopsys-dwc-arc-processors/qemu/issues/154